### PR TITLE
fixes buffer-over-read

### DIFF
--- a/ext/escape_utils/escape_utils.c
+++ b/ext/escape_utils/escape_utils.c
@@ -233,6 +233,7 @@ static size_t unescape_url(unsigned char *out, const unsigned char *in, size_t i
       if (IS_HEX(*in) && IS_HEX(*(in+1))) {
         *out++ = (UNHEX(*in) << 4) + UNHEX(*(in+1));
         in+=2;
+        len-=2;
         total-=2;
       } else {
         /* incomplete escape, pass it through */
@@ -283,6 +284,7 @@ static size_t unescape_uri(unsigned char *out, const unsigned char *in, size_t i
       if (IS_HEX(*in) && IS_HEX(*(in+1))) {
         *out++ = (UNHEX(*in) << 4) + UNHEX(*(in+1));
         in+=2;
+        len-=2;
         total-=2;
       } else {
         /* incomplete escape, pass it through */


### PR DESCRIPTION
This patch fixes buffer-over-read issue in unescape_url() and unescape_uri() .

The buffer-over-read issue may return a shorter result when reading not intended "%xx". If in utf-8 string, this raises exception like "invalid byte sequence in UTF-8".
