### PR TITLE
Rubinius compatibility

### DIFF
--- a/ext/escape_utils/escape_utils.c
+++ b/ext/escape_utils/escape_utils.c
@@ -1,7 +1,7 @@
+#include <ruby.h>
 #if RB_CVAR_SET_ARITY == 4
 #  define rb_cvar_set(a,b,c) rb_cvar_set(a,b,c,0)
 #endif
-#include <ruby.h>
 #ifdef HAVE_RUBY_ENCODING_H
 #include <ruby/encoding.h>
 #endif


### PR DESCRIPTION
Hello,

I tried to gem install escape_utils under Rubinius, it wouldn't compile.
I found that moving that #include <ruby.h> line to the top makes it compile and work in rbx and 1.8.7

Not sure if that's the right way to fix it, you be the judge :)

Regards
Karol
