### PR TITLE
Link with -Bsymbolic to make sure we use the local copy of houdini

### DIFF
--- a/ext/escape_utils/escape_utils.c
+++ b/ext/escape_utils/escape_utils.c
@@ -217,6 +217,7 @@ static VALUE rb_eu_unescape_uri(VALUE self, VALUE str)
 /**
  * Ruby Extension initializer
  */
+__attribute__((visibility("default")))
 void Init_escape_utils()
 {
 #ifdef HAVE_RUBY_ENCODING_H

--- a/ext/escape_utils/extconf.rb
+++ b/ext/escape_utils/extconf.rb
@@ -1,6 +1,6 @@
 require 'mkmf'
 
-$CFLAGS << ' -Wall -funroll-loops'
+$CFLAGS << ' -Wall -funroll-loops -fvisibility=hidden'
 $CFLAGS << ' -Wextra -O0 -ggdb3' if ENV['DEBUG']
 
 create_makefile("escape_utils/escape_utils")


### PR DESCRIPTION
If `escape_utils` is used with another gem (like `redcarpet`) that also has a copy of houdini inside then the dynamic linker can wind up using the wrong version of the houdini routines.

Adding `-Bsymbolic` to the linker flags tells the linker to prefer the local version when resolving symbols.

I assume this will actually need some guarding so that it only happens on ELF systems using the `binutils` linker but I have no idea how to achieve that...
