### PR TITLE
Update for ruby 2.1.0-dev

### DIFF
--- a/ext/escape_utils/escape_utils.c
+++ b/ext/escape_utils/escape_utils.c
@@ -115,18 +115,10 @@ static VALUE rb_eu_escape_html_as_html_safe(VALUE self, VALUE str)
 		result = eu_new_str(buf.ptr, buf.size);
 		gh_buf_free(&buf);
 	} else {
-#ifdef RBASIC
-		result = rb_str_dup(str);
-#else
 		result = str;
-#endif
 	}
 
-#ifdef RBASIC
-	RBASIC(result)->klass = rb_html_safe_string_class;
-#else
 	result = rb_funcall(rb_html_safe_string_class, ID_new, 1, result);
-#endif
 
 	rb_ivar_set(result, ID_at_html_safe, Qtrue);
 


### PR DESCRIPTION
RBASIC->klass is write protected in ruby 2.1.0-dev

Tried to use RBASIC_SET_CLASS or RBASIC_SET_CLASS_RAW but they are not available (maybe we should probably wait for now since this is not final).

Not sure what the performance impact is here.

See [Issue #42](https://github.com/brianmario/escape_utils/issues/42) for more details.
