### PR TITLE
Failing test for unescaping plus sign

### DIFF
--- a/test/url/escape_test.rb
+++ b/test/url/escape_test.rb
@@ -22,6 +22,10 @@ class UriEscapeTest < Minitest::Test
     assert_equal "a+++sp+ace+", EscapeUtils.escape_url("a   sp ace ")
   end
 
+  def test_url_containing_plus_sign
+    assert_equal "a%2Bplus", EscapeUtils.escape_url("a+plus")
+  end
+
   def test_url_containing_mixed_characters
     assert_equal "q1%212%22%27w%245%267%2Fz8%29%3F%5C", EscapeUtils.escape_url("q1!2\"'w$5&7/z8)?\\")
   end

--- a/test/url/unescape_test.rb
+++ b/test/url/unescape_test.rb
@@ -21,6 +21,10 @@ class UriUnescapeTest < Minitest::Test
     assert_equal "a space", EscapeUtils.unescape_url("a+space")
   end
 
+  def test_url_containing_plus_sign
+    assert_equal "plus+sign", EscapeUtils.unescape_url("plus%2Bsign")
+  end
+
   def test_url_containing_mixed_characters
     assert_equal "q1!2\"'w$5&7/z8)?\\", EscapeUtils.unescape_url("q1%212%22%27w%245%267%2Fz8%29%3F%5C")
     assert_equal "q1!2\"'w$5&7/z8)?\\", EscapeUtils.unescape_url("q1!2%22'w$5&7/z8)?%5C")


### PR DESCRIPTION
This PR adds a couple of tests on escaping/unescaping urls containing plus sign, a case that was not covered. `unscape_url("%2B")` returns a space instead of a +, so the test suite fails now.
There's a [reported bug](https://github.com/vmg/houdini/issues/10) in Houdini, so once it's addressed and updated, this test should pass.
