### PR TITLE
Don't write to RBasic::klass

### DIFF
--- a/ext/escape_utils/escape_utils.c
+++ b/ext/escape_utils/escape_utils.c
@@ -115,18 +115,10 @@ static VALUE rb_eu_escape_html_as_html_safe(VALUE self, VALUE str)
 		result = eu_new_str(buf.ptr, buf.size);
 		gh_buf_free(&buf);
 	} else {
-#ifdef RBASIC
-		result = rb_str_dup(str);
-#else
 		result = str;
-#endif
 	}
 
-#ifdef RBASIC
-	RBASIC(result)->klass = rb_html_safe_string_class;
-#else
 	result = rb_funcall(rb_html_safe_string_class, ID_new, 1, result);
-#endif
 
 	rb_ivar_set(result, ID_at_html_safe, Qtrue);
 


### PR DESCRIPTION
Ruby 2.1 will make `RBasic::klass` read-only as part of the RGenGC work.

Currently, this gem fails to compile against Ruby trunk. This pull request fixes the compilation failure by deleting the code path that writes to `RBasic::klass`.
