### PR TITLE
Use rb_str_new_with_class instead of setting klass

### DIFF
--- a/ext/escape_utils/extconf.rb
+++ b/ext/escape_utils/extconf.rb
@@ -3,4 +3,6 @@ require 'mkmf'
 $CFLAGS << ' -Wall -funroll-loops -fvisibility=hidden'
 $CFLAGS << ' -Wextra -O0 -ggdb3' if ENV['DEBUG']
 
+have_func("rb_str_new_with_class")
+
 create_makefile("escape_utils/escape_utils")


### PR DESCRIPTION
Alternative approach to #44.

Uses the `rb_str_new_with_class` API for creating a new string of a given class instead of setting it manually (which won't work in 2.1)
