### PR TITLE
update gemspec metadata

### DIFF
--- a/escape_utils.gemspec
+++ b/escape_utils.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.email = %q{seniorlopez@gmail.com}
   s.extensions = ["ext/escape_utils/extconf.rb"]
   s.files = `git ls-files`.split("\n")
-  s.homepage = %q{http://github.com/brianmario/escape_utils}
+  s.homepage = %q{https://github.com/brianmario/escape_utils}
   s.license = %q{MIT}
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]


### PR DESCRIPTION
This pull request updates two things in the gemspec metadata: it adds a bit of description text, and updates the homepage URL to use HTTPS.

This change allows RubyGems.org and other tools (such as gem2rpm) to display a helpful description to users.
