### PR TITLE
Add support for (un)escape_uri_component

### DIFF
--- a/ext/escape_utils/buffer.c
+++ b/ext/escape_utils/buffer.c
@@ -242,7 +242,7 @@ void gh_buf_attach(gh_buf *buf, char *ptr, size_t asize)
 
 int gh_buf_cmp(const gh_buf *a, const gh_buf *b)
 {
-	int result = memcmp(a->ptr, b->ptr, (a->size < b->size) ? a->size : b->size);
+	int result = memcmp(a->ptr, b->ptr, MIN(a->size, b->size));
 	return (result != 0) ? result :
 		(a->size < b->size) ? -1 : (a->size > b->size) ? 1 : 0;
 }

--- a/ext/escape_utils/escape_utils.c
+++ b/ext/escape_utils/escape_utils.c
@@ -202,6 +202,19 @@ static VALUE rb_eu_unescape_uri(VALUE self, VALUE str)
 	return rb_eu__generic(str, &houdini_unescape_uri);
 }
 
+/**
+ * URI component methods
+ */
+static VALUE rb_eu_escape_uri_component(VALUE self, VALUE str)
+{
+	return rb_eu__generic(str, &houdini_escape_uri_component);
+}
+
+static VALUE rb_eu_unescape_uri_component(VALUE self, VALUE str)
+{
+	return rb_eu__generic(str, &houdini_unescape_uri_component);
+}
+
 
 /**
  * Ruby Extension initializer
@@ -227,6 +240,8 @@ void Init_escape_utils()
 	rb_define_method(rb_mEscapeUtils, "unescape_url", rb_eu_unescape_url, 1);
 	rb_define_method(rb_mEscapeUtils, "escape_uri", rb_eu_escape_uri, 1);
 	rb_define_method(rb_mEscapeUtils, "unescape_uri", rb_eu_unescape_uri, 1);
+	rb_define_method(rb_mEscapeUtils, "escape_uri_component", rb_eu_escape_uri_component, 1);
+	rb_define_method(rb_mEscapeUtils, "unescape_uri_component", rb_eu_unescape_uri_component, 1);
 
 	rb_define_singleton_method(rb_mEscapeUtils, "html_secure=", rb_eu_set_html_secure, 1);
 	rb_define_singleton_method(rb_mEscapeUtils, "html_safe_string_class=", rb_eu_set_html_safe_string_class, 1);

--- a/ext/escape_utils/houdini.h
+++ b/ext/escape_utils/houdini.h
@@ -30,9 +30,11 @@ extern int houdini_escape_html0(gh_buf *ob, const uint8_t *src, size_t size, int
 extern int houdini_unescape_html(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_escape_xml(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_escape_uri(gh_buf *ob, const uint8_t *src, size_t size);
+extern int houdini_escape_uri_component(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_escape_url(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_escape_href(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_unescape_uri(gh_buf *ob, const uint8_t *src, size_t size);
+extern int houdini_unescape_uri_component(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_unescape_url(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_escape_js(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_unescape_js(gh_buf *ob, const uint8_t *src, size_t size);

--- a/ext/escape_utils/houdini_html_u.c
+++ b/ext/escape_utils/houdini_html_u.c
@@ -57,7 +57,7 @@ unescape_ent(gh_buf *ob, const uint8_t *src, size_t size)
 				codepoint = (codepoint * 16) + ((src[i] | 32) % 39 - 9);
 		}
 
-		if (i < size && src[i] == ';') {
+		if (i < size && src[i] == ';' && codepoint) {
 			gh_buf_put_utf8(ob, codepoint);
 			return i + 1;
 		}

--- a/ext/escape_utils/houdini_uri_e.c
+++ b/ext/escape_utils/houdini_uri_e.c
@@ -43,10 +43,10 @@ static const char URI_SAFE[] = {
 };
 
 static int
-escape(gh_buf *ob, const uint8_t *src, size_t size, int is_url)
+escape(gh_buf *ob, const uint8_t *src, size_t size,
+	const char *safe_table, bool escape_plus)
 {
 	static const uint8_t hex_chars[] = "0123456789ABCDEF";
-	const char *safe_table = is_url ? URL_SAFE : URI_SAFE;
 
 	size_t  i = 0, org;
 	uint8_t hex_str[3];
@@ -73,7 +73,7 @@ escape(gh_buf *ob, const uint8_t *src, size_t size, int is_url)
 		if (i >= size)
 			break;
 
-		if (src[i] == ' ' && is_url) {
+		if (src[i] == ' ' && escape_plus) {
 			gh_buf_putc(ob, '+');
 		} else {
 			hex_str[1] = hex_chars[(src[i] >> 4) & 0xF];
@@ -90,12 +90,18 @@ escape(gh_buf *ob, const uint8_t *src, size_t size, int is_url)
 int
 houdini_escape_uri(gh_buf *ob, const uint8_t *src, size_t size)
 {
-	return escape(ob, src, size, 0);
+	return escape(ob, src, size, URI_SAFE, false);
+}
+
+int
+houdini_escape_uri_component(gh_buf *ob, const uint8_t *src, size_t size)
+{
+	return escape(ob, src, size, URL_SAFE, false);
 }
 
 int
 houdini_escape_url(gh_buf *ob, const uint8_t *src, size_t size)
 {
-	return escape(ob, src, size, 1);
+	return escape(ob, src, size, URL_SAFE, true);
 }
 

--- a/ext/escape_utils/houdini_uri_u.c
+++ b/ext/escape_utils/houdini_uri_u.c
@@ -7,18 +7,18 @@
 #define hex2c(c) ((c | 32) % 39 - 9)
 
 static int
-unescape(gh_buf *ob, const uint8_t *src, size_t size, int is_url)
+unescape(gh_buf *ob, const uint8_t *src, size_t size, bool unescape_plus)
 {
 	size_t  i = 0, org;
 
 	while (i < size) {
 		org = i;
-		while (i < size && src[i] != '%')
+		while (i < size && src[i] != '%' && src[i] != '+')
 			i++;
 
 		if (likely(i > org)) {
 			if (unlikely(org == 0)) {
-				if (i >= size && !is_url)
+				if (i >= size)
 					return 0;
 
 				gh_buf_grow(ob, HOUDINI_UNESCAPED_SIZE(size));
@@ -31,7 +31,10 @@ unescape(gh_buf *ob, const uint8_t *src, size_t size, int is_url)
 		if (i >= size)
 			break;
 
-		i++;
+		if (src[i++] == '+') {
+			gh_buf_putc(ob, unescape_plus ? ' ' : '+');
+			continue;
+		}
 
 		if (i + 1 < size && _isxdigit(src[i]) && _isxdigit(src[i + 1])) {
 			unsigned char new_char = (hex2c(src[i]) << 4) + hex2c(src[i + 1]);
@@ -42,24 +45,24 @@ unescape(gh_buf *ob, const uint8_t *src, size_t size, int is_url)
 		}
 	}
 
-	if (is_url) {
-		char *find = (char *)gh_buf_cstr(ob);
-		while ((find = strchr(find, '+')) != NULL)
-			*find = ' ';
-	}
-
 	return 1;
 }
 
 int
 houdini_unescape_uri(gh_buf *ob, const uint8_t *src, size_t size)
 {
-	return unescape(ob, src, size, 0);
+	return unescape(ob, src, size, false);
+}
+
+int
+houdini_unescape_uri_component(gh_buf *ob, const uint8_t *src, size_t size)
+{
+	return unescape(ob, src, size, false);
 }
 
 int
 houdini_unescape_url(gh_buf *ob, const uint8_t *src, size_t size)
 {
-	return unescape(ob, src, size, 1);
+	return unescape(ob, src, size, true);
 }
 

--- a/test/uri/escape_test.rb
+++ b/test/uri/escape_test.rb
@@ -25,6 +25,14 @@ class UriEscapeTest < Minitest::Test
     assert_equal '%E3%81%BE%E3%81%A4%20%E3%82%82%E3%81%A8', EscapeUtils.escape_uri(matz_name_sep)
   end
 
+  def test_uri_containing_pluses
+    assert_equal "a+plus", EscapeUtils.escape_uri("a+plus")
+  end
+
+  def test_uri_containing_slashes
+    assert_equal "a/slash", EscapeUtils.escape_uri("a/slash")
+  end
+
   if RUBY_VERSION =~ /^1.9/
     def test_input_must_be_utf8_or_ascii
       str = "fo<o>bar"

--- a/test/uri/unescape_test.rb
+++ b/test/uri/unescape_test.rb
@@ -30,18 +30,29 @@ class UriUnescapeTest < Minitest::Test
     assert_equal matz_name_sep, EscapeUtils.unescape_uri('%E3%81%BE%E3%81%A4%20%E3%82%82%E3%81%A8')
   end
 
+  def test_uri_containing_pluses
+    assert_equal "a+plus", EscapeUtils.unescape_uri("a%2Bplus")
+  end
+
+  def test_escape_unescape_roundtrip
+    (0..127).each do |index|
+      char = index.chr
+      assert_equal char, EscapeUtils.unescape_uri(EscapeUtils.escape_uri(char))
+    end
+  end
+
   if RUBY_VERSION =~ /^1.9/
     def test_input_must_be_valid_utf8_or_ascii
       escaped = EscapeUtils.escape_uri("fo<o>bar")
 
       escaped.force_encoding 'ISO-8859-1'
       assert_raises Encoding::CompatibilityError do
-        EscapeUtils.unescape_url(escaped)
+        EscapeUtils.unescape_uri(escaped)
       end
 
       escaped.force_encoding 'UTF-8'
       begin
-        EscapeUtils.unescape_url(escaped)
+        EscapeUtils.unescape_uri(escaped)
       rescue Encoding::CompatibilityError => e
         assert_nil e, "#{e.class.name} raised, expected not to"
       end
@@ -49,7 +60,7 @@ class UriUnescapeTest < Minitest::Test
 
     def test_return_value_is_tagged_as_utf8
       escaped = EscapeUtils.escape_uri("a space")
-      assert_equal Encoding.find('UTF-8'), EscapeUtils.unescape_url(escaped).encoding
+      assert_equal Encoding.find('UTF-8'), EscapeUtils.unescape_uri(escaped).encoding
     end
   end
 end

--- a/test/uri_component/escape_test.rb
+++ b/test/uri_component/escape_test.rb
@@ -1,0 +1,68 @@
+require File.expand_path("../../helper", __FILE__)
+require 'cgi'
+
+class UriComponentEscapeTest < Minitest::Test
+  def test_basic_url
+    assert_equal "http%3A%2F%2Fwww.homerun.com%2F", EscapeUtils.escape_uri_component("http://www.homerun.com/")
+  end
+
+  def test_cgi_equivalence
+    (0..127).each do |i|
+      c = i.chr
+      # Escaping URI path components should match CGI parameter escaping, except
+      # spaces should be escaped as "%20" instead of "+"
+      assert_equal CGI.escape(c).sub("+", "%20"), EscapeUtils.escape_uri_component(c)
+    end
+  end
+
+  def test_uri_component_containing_tags
+    assert_equal "fo%3Co%3Ebar", EscapeUtils.escape_uri_component("fo<o>bar")
+  end
+
+  def test_uri_component_containing_tags_containing_spaces
+    assert_equal "a%20space", EscapeUtils.escape_uri_component("a space")
+    assert_equal "a%20%20%20sp%20ace%20", EscapeUtils.escape_uri_component("a   sp ace ")
+  end
+
+  def test_uri_component_containing_mixed_characters
+    assert_equal "q1%212%22%27w%245%267%2Fz8%29%3F%5C", EscapeUtils.escape_uri_component("q1!2\"'w$5&7/z8)?\\")
+  end
+
+  def test_multibyte_characters
+    matz_name = "\xE3\x81\xBE\xE3\x81\xA4\xE3\x82\x82\xE3\x81\xA8" # Matsumoto
+    assert_equal '%E3%81%BE%E3%81%A4%E3%82%82%E3%81%A8', EscapeUtils.escape_uri_component(matz_name)
+    matz_name_sep = "\xE3\x81\xBE\xE3\x81\xA4 \xE3\x82\x82\xE3\x81\xA8" # Matsu moto
+    assert_equal '%E3%81%BE%E3%81%A4%20%E3%82%82%E3%81%A8', EscapeUtils.escape_uri_component(matz_name_sep)
+  end
+
+  def test_uri_component_containing_pluses
+    assert_equal "a%2Bplus", EscapeUtils.escape_uri_component("a+plus")
+  end
+
+  def test_uri_component_containing_slashes
+    assert_equal "a%2Fslash", EscapeUtils.escape_uri_component("a/slash")
+  end
+
+  if RUBY_VERSION =~ /^1.9/
+    def test_input_must_be_utf8_or_ascii
+      str = "fo<o>bar"
+
+      str.force_encoding 'ISO-8859-1'
+      assert_raises Encoding::CompatibilityError do
+        EscapeUtils.escape_uri_component(str)
+      end
+
+      str.force_encoding 'UTF-8'
+      begin
+        EscapeUtils.escape_uri_component(str)
+      rescue Encoding::CompatibilityError => e
+        assert_nil e, "#{e.class.name} raised, expected not to"
+      end
+    end
+
+    def test_return_value_is_tagged_as_utf8
+      str = "fo<o>bar"
+      assert_equal Encoding.find('UTF-8'), EscapeUtils.escape_uri_component(str).encoding
+    end
+  end
+end

--- a/test/uri_component/unescape_test.rb
+++ b/test/uri_component/unescape_test.rb
@@ -1,0 +1,71 @@
+require File.expand_path("../../helper", __FILE__)
+
+class UriComponentUnescapeTest < Minitest::Test
+  def test_basic_url
+    assert_equal "http://www.homerun.com/", EscapeUtils.unescape_uri_component("http%3A%2F%2Fwww.homerun.com%2F")
+    assert_equal "http://www.homerun.com/", EscapeUtils.unescape_uri_component("http://www.homerun.com/")
+  end
+
+  def test_doesnt_unescape_an_incomplete_escape
+    assert_equal "%", EscapeUtils.unescape_uri_component("%")
+    assert_equal "http%", EscapeUtils.unescape_uri_component("http%")
+  end
+
+  def test_uri_component_containing_tags
+    assert_equal "fo<o>bar", EscapeUtils.unescape_uri_component("fo%3Co%3Ebar")
+  end
+
+  def test_uri_component_containing_spaces
+    assert_equal "a space", EscapeUtils.unescape_uri_component("a%20space")
+    assert_equal "a   sp ace ", EscapeUtils.unescape_uri_component("a%20%20%20sp%20ace%20")
+  end
+
+  def test_uri_component_containing_pluses
+    assert_equal "a+plus", EscapeUtils.unescape_uri_component("a%2Bplus")
+    assert_equal "a+plus", EscapeUtils.unescape_uri_component("a+plus")
+  end
+
+  def test_escape_unescape_roundtrip
+    (0..127).each do |index|
+      char = index.chr
+      assert_equal char, EscapeUtils.unescape_uri_component(EscapeUtils.escape_uri_component(char))
+    end
+  end
+
+  def test_uri_component_containing_mixed_characters
+    assert_equal "q1!2\"'w$5&7/z8)?\\", EscapeUtils.unescape_uri_component("q1%212%22%27w%245%267%2Fz8%29%3F%5C")
+    assert_equal "q1!2\"'w$5&7/z8)?\\", EscapeUtils.unescape_uri_component("q1!2%22'w$5&7/z8)?%5C")
+  end
+
+  def test_multibyte_characters
+    matz_name = "\xE3\x81\xBE\xE3\x81\xA4\xE3\x82\x82\xE3\x81\xA8" # Matsumoto
+    matz_name.force_encoding('UTF-8') if matz_name.respond_to?(:force_encoding)
+    assert_equal matz_name, EscapeUtils.unescape_uri_component('%E3%81%BE%E3%81%A4%E3%82%82%E3%81%A8')
+    matz_name_sep = "\xE3\x81\xBE\xE3\x81\xA4 \xE3\x82\x82\xE3\x81\xA8" # Matsu moto
+    matz_name_sep.force_encoding('UTF-8') if matz_name_sep.respond_to?(:force_encoding)
+    assert_equal matz_name_sep, EscapeUtils.unescape_uri_component('%E3%81%BE%E3%81%A4%20%E3%82%82%E3%81%A8')
+  end
+
+  if RUBY_VERSION =~ /^1.9/
+    def test_input_must_be_valid_utf8_or_ascii
+      escaped = EscapeUtils.escape_uri_component("fo<o>bar")
+
+      escaped.force_encoding 'ISO-8859-1'
+      assert_raises Encoding::CompatibilityError do
+        EscapeUtils.unescape_uri_component(escaped)
+      end
+
+      escaped.force_encoding 'UTF-8'
+      begin
+        EscapeUtils.unescape_uri_component(escaped)
+      rescue Encoding::CompatibilityError => e
+        assert_nil e, "#{e.class.name} raised, expected not to"
+      end
+    end
+
+    def test_return_value_is_tagged_as_utf8
+      escaped = EscapeUtils.escape_uri_component("fo<o>bar")
+      assert_equal Encoding.find('UTF-8'), EscapeUtils.unescape_uri_component(escaped).encoding
+    end
+  end
+end

--- a/test/url/escape_test.rb
+++ b/test/url/escape_test.rb
@@ -1,7 +1,7 @@
 require File.expand_path("../../helper", __FILE__)
 require 'cgi'
 
-class UriEscapeTest < Minitest::Test
+class UrlEscapeTest < Minitest::Test
   def test_basic_url
     assert_equal "http%3A%2F%2Fwww.homerun.com%2F", EscapeUtils.escape_url("http://www.homerun.com/")
   end
@@ -31,6 +31,14 @@ class UriEscapeTest < Minitest::Test
     assert_equal '%E3%81%BE%E3%81%A4%E3%82%82%E3%81%A8', EscapeUtils.escape_url(matz_name)
     matz_name_sep = "\xE3\x81\xBE\xE3\x81\xA4 \xE3\x82\x82\xE3\x81\xA8" # Matsu moto
     assert_equal '%E3%81%BE%E3%81%A4+%E3%82%82%E3%81%A8', EscapeUtils.escape_url(matz_name_sep)
+  end
+
+  def test_url_containing_pluses
+    assert_equal "a%2Bplus", EscapeUtils.escape_url("a+plus")
+  end
+
+  def test_url_containing_slashes
+    assert_equal "a%2Fslash", EscapeUtils.escape_url("a/slash")
   end
 
   if RUBY_VERSION =~ /^1.9/

--- a/test/url/unescape_test.rb
+++ b/test/url/unescape_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path("../../helper", __FILE__)
 
-class UriUnescapeTest < Minitest::Test
+class UrlUnescapeTest < Minitest::Test
   def test_basic_url
     assert_equal "http://www.homerun.com/", EscapeUtils.unescape_url("http%3A%2F%2Fwww.homerun.com%2F")
     assert_equal "http://www.homerun.com/", EscapeUtils.unescape_url("http://www.homerun.com/")
@@ -35,9 +35,20 @@ class UriUnescapeTest < Minitest::Test
     assert_equal matz_name_sep, EscapeUtils.unescape_url('%E3%81%BE%E3%81%A4%20%E3%82%82%E3%81%A8')
   end
 
+  def test_url_containing_pluses
+    assert_equal "a+plus", EscapeUtils.unescape_url("a%2Bplus")
+  end
+
+  def test_escape_unescape_roundtrip
+    (0..127).each do |index|
+      char = index.chr
+      assert_equal char, EscapeUtils.unescape_url(EscapeUtils.escape_url(char))
+    end
+  end
+
   if RUBY_VERSION =~ /^1.9/
     def test_input_must_be_valid_utf8_or_ascii
-      escaped = EscapeUtils.escape_uri("fo<o>bar")
+      escaped = EscapeUtils.escape_url("fo<o>bar")
 
       escaped.force_encoding 'ISO-8859-1'
       assert_raises Encoding::CompatibilityError do
@@ -53,7 +64,7 @@ class UriUnescapeTest < Minitest::Test
     end
 
     def test_return_value_is_tagged_as_utf8
-      escaped = EscapeUtils.escape_uri("fo<o>bar")
+      escaped = EscapeUtils.escape_url("fo<o>bar")
       assert_equal Encoding.find('UTF-8'), EscapeUtils.unescape_url(escaped).encoding
     end
   end


### PR DESCRIPTION
Thanks to @vmg adding support for `(un)escape_uri_component` in https://github.com/vmg/houdini/pull/16, we can add this support to EscapeUtils. This should be useful for escaping path components where you want to escape any/all values that could be misinterpreted as part of a URI path but you don't want param escaping (i.e. space == `+`). This is very much analogous to JavaScripts [encodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) function.

https://github.com/vmg/houdini/pull/16 also fixed the `+` to space translation bug. Finally, I fixed up a few tests that looked like they were misname/using the wrong method.


fixes #31, fixes #54, fixes #23