### PR TITLE
Providing MIN macro definition where unavailable

### DIFF
--- a/ext/escape_utils/buffer.h
+++ b/ext/escape_utils/buffer.h
@@ -110,4 +110,10 @@ extern void gh_buf_clear(gh_buf *buf);
 
 #define gh_buf_PUTS(buf, str) gh_buf_put(buf, str, sizeof(str) - 1)
 
+/* support for environments where MIN is not provided */
+
+#ifndef MIN
+#define	MIN(a,b) (((a)<(b))?(a):(b))
+#endif
+
 #endif


### PR DESCRIPTION
There are some environments (like Windows(x64) mingw) where MIN macro is not provided.

Add MIN definition (only when it's undefined) in buffer.h to be compatible to these environments.