### PR TITLE
fix wikipedia url for benchmarking html escape/unescape

### DIFF
--- a/benchmark/html_escape.rb
+++ b/benchmark/html_escape.rb
@@ -15,7 +15,7 @@ module HamlBench
   extend Haml::Helpers
 end
 
-url = "http://en.wikipedia.org/wiki/Line_of_succession_to_the_British_throne"
+url = "https://en.wikipedia.org/wiki/Succession_to_the_British_throne"
 html = `curl -s #{url}`
 html = html.force_encoding('utf-8') if html.respond_to?(:force_encoding)
 puts "Escaping #{html.bytesize} bytes of html from #{url}"

--- a/benchmark/html_unescape.rb
+++ b/benchmark/html_unescape.rb
@@ -12,7 +12,7 @@ module HamlBench
   extend Haml::Helpers
 end
 
-url = "http://en.wikipedia.org/wiki/Line_of_succession_to_the_British_throne"
+url = "https://en.wikipedia.org/wiki/Succession_to_the_British_throne"
 html = `curl -s #{url}`
 html = html.force_encoding('binary') if html.respond_to?(:force_encoding)
 escaped_html = EscapeUtils.escape_html(html)


### PR DESCRIPTION
Changed the url to actually get data to work on.