### PR TITLE
fix encoding of the escaped html safe string

### DIFF
--- a/ext/escape_utils/escape_utils.c
+++ b/ext/escape_utils/escape_utils.c
@@ -118,6 +118,7 @@ static VALUE rb_eu_escape_html_as_html_safe(VALUE self, VALUE str)
 	}
 
 	rb_ivar_set(result, ID_at_html_safe, Qtrue);
+	rb_enc_associate(result, rb_enc_get(str));
 
 	return result;
 }

--- a/test/html/escape_test.rb
+++ b/test/html/escape_test.rb
@@ -4,6 +4,30 @@ class MyCustomHtmlSafeString < String
 end
 
 class HtmlEscapeTest < Minitest::Test
+  def test_escape_source_encoding_is_maintained
+    source = 'foobar'
+    str = EscapeUtils.escape_html_as_html_safe(source)
+    assert_equal source.encoding, str.encoding
+  end
+
+  def test_escape_binary_encoding_is_maintained
+    source = 'foobar'.b
+    str = EscapeUtils.escape_html_as_html_safe(source)
+    assert_equal source.encoding, str.encoding
+  end
+
+  def test_escape_uft8_encoding_is_maintained
+    source = 'foobar'.encode 'UTF-8'
+    str = EscapeUtils.escape_html_as_html_safe(source)
+    assert_equal source.encoding, str.encoding
+  end
+
+  def test_escape_us_ascii_encoding_is_maintained
+    source = 'foobar'.encode 'US-ASCII'
+    str = EscapeUtils.escape_html_as_html_safe(source)
+    assert_equal source.encoding, str.encoding
+  end
+
   def test_escape_basic_html_with_secure
     assert_equal "&lt;some_tag&#47;&gt;", EscapeUtils.escape_html("<some_tag/>")
 


### PR DESCRIPTION
`escape_html_as_html_safe` was returning binary strings which will
infect all the UTF-8 strings in our view layer.  This patch tags the
return string with the encoding of the source string so that we're not
eventually forcing everything to be binary.