### PR TITLE
Refer to the top level EscapeUtils constant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
 
 gemspec
+
+if RUBY_VERSION < '2.2.2'
+  gem 'rack', '< 2'
+end

--- a/lib/escape_utils/xml/builder.rb
+++ b/lib/escape_utils/xml/builder.rb
@@ -2,7 +2,7 @@ module Builder
   class XmlBase < BlankSlate
     private
     def _escape(text)
-      EscapeUtils.escape_xml(text.to_s)
+      ::EscapeUtils.escape_xml(text.to_s)
     end
   end
 end


### PR DESCRIPTION
This will fix the error

   NameError: uninitialized constant Builder::XmlBase::EscapeUtils

when trying to use the Builder monkey patch.