### PR TITLE
Fixing Undefined reference to `MIN' in 1.1.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ tmp/
 Gemfile.lock
 vendor/*
 bin/
+*.gem
+*.def
+*.so

--- a/ext/escape_utils/buffer.h
+++ b/ext/escape_utils/buffer.h
@@ -21,6 +21,8 @@ typedef struct {
 extern char gh_buf__initbuf[];
 extern char gh_buf__oom[];
 
+#define MIN(X,Y) ((X) < (Y) ? (X) : (Y))
+
 #define GH_BUF_INIT { gh_buf__initbuf, 0, 0 }
 
 /**

--- a/lib/escape_utils/version.rb
+++ b/lib/escape_utils/version.rb
@@ -1,3 +1,3 @@
 module EscapeUtils
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end


### PR DESCRIPTION
GitHub Linguist currently [requires a 1.1.x release](https://github.com/github/linguist/blob/master/github-linguist.gemspec) of escape_utils.

The 1.1.1 release currently does not work under Windows due to #60. This is a small patch to the 1.1.x release branch (making it 1.1.2) that fixes the Windows install issue, and allows Linguist to function.

I have run all the tests and they are passing. Please consider merging this to make a 1.1.2 version.