### PR TITLE
Prepare release 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 1.2.2
+
 - Update EscapeUtils.escape_javascript to match Rails `escape_javascript`
   Now escapes, Backquotes (```), Dollar (`$`), `U+2000` and `U+2001`
 - Make the Rack monkey patch a noop as it's no longer correct since circa 2011.

--- a/lib/escape_utils/version.rb
+++ b/lib/escape_utils/version.rb
@@ -1,3 +1,3 @@
 module EscapeUtils
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end


### PR DESCRIPTION
Here's the current diff: https://github.com/brianmario/escape_utils/compare/brianmario:2f28447...brianmario:8c8a36e

Also see the CHANGELOG.

It's debatable wether a patch release qualify, I tried to only do fixes, but some fixes are to better match the behavior of things we monkey patch, so depending on how you look at it, it can be breaking changes instead of fixes.

The reason I'd like a patch release however is that there's a bunch of gems out there with a `~> 1.2.0` dependency, and I think it makes sense to offer them a fix. For any further changes we could go with a `1.3` or even `2.0`.

@jhawthorn would love if you could review.