### PR TITLE
Add escape_html_once and escape_html_once_as_safe_html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add `EscapeUtils.escape_html_once` and `EscapeUtils.rb_eu_escape_html_once_as_html_safe` as faster implementations of Rails `escape_once` helper.
+
 # 1.2.2
 
 - Update EscapeUtils.escape_javascript to match Rails `escape_javascript`

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ or per-call by passing `false` as the second parameter to `escape_html` like `Es
 
 For more information check out: http://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet#RULE_.231_-_HTML_Escape_Before_Inserting_Untrusted_Data_into_HTML_Element_Content
 
+To avoid double-escaping HTML entities, use `EscapeUtils.escape_html_once`.
+
 #### Unescaping
 
 ``` ruby

--- a/benchmark/html_escape_once.rb
+++ b/benchmark/html_escape_once.rb
@@ -1,0 +1,25 @@
+# encoding: utf-8
+
+require 'rubygems'
+require 'bundler/setup'
+require 'benchmark/ips'
+
+require 'escape_utils'
+require 'active_support/core_ext/string/output_safety'
+
+url = "https://en.wikipedia.org/wiki/Succession_to_the_British_throne"
+html = `curl -s #{url}`
+html = html.force_encoding('utf-8') if html.respond_to?(:force_encoding)
+puts "Escaping #{html.bytesize} bytes of html from #{url}"
+
+Benchmark.ips do |x|
+  x.report "EscapeUtils.escape_html_once" do
+    EscapeUtils.escape_html_once(html)
+  end
+
+  x.report "ActionView escape_once" do # Rails expose it as ERB::Util.html_escape_once
+    ERB::Util.html_escape_once(html)
+  end
+
+  x.compare!(order: :baseline)
+end

--- a/ext/escape_utils/houdini.h
+++ b/ext/escape_utils/houdini.h
@@ -22,11 +22,13 @@ extern "C" {
 #	define _isdigit(c) ((c) >= '0' && (c) <= '9')
 #endif
 
+#define _isasciialpha(c) (((c) >= 'a' && (c) <= 'z') || ((c) >= 'A' && (c) <= 'Z'))
+
 #define HOUDINI_ESCAPED_SIZE(x) (((x) * 12) / 10)
 #define HOUDINI_UNESCAPED_SIZE(x) (x)
 
 extern int houdini_escape_html(gh_buf *ob, const uint8_t *src, size_t size);
-extern int houdini_escape_html0(gh_buf *ob, const uint8_t *src, size_t size, int secure);
+extern int houdini_escape_html0(gh_buf *ob, const uint8_t *src, size_t size, int secure, int escape_once);
 extern int houdini_unescape_html(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_escape_xml(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_escape_uri(gh_buf *ob, const uint8_t *src, size_t size);

--- a/test/html/escape_test.rb
+++ b/test/html/escape_test.rb
@@ -63,6 +63,30 @@ class HtmlEscapeTest < Minitest::Test
     assert_equal str.object_id, EscapeUtils.escape_html(str).object_id
   end
 
+  def test_escape_html_once
+    {
+      '&<' => '&amp;&lt;',
+      '&amp;&lt;&x;' => '&amp;&lt;&x;',
+      '&amp' => '&amp;amp',
+      '&!;' => '&amp;!;',
+      '&#0;' => '&#0;',
+      '&#10;' => '&#10;',
+      '&#10' => '&amp;#10',
+      '&#10000000000;' => '&#10000000000;',
+      '&#x0;' => '&#x0;',
+      '&#xf0;' => '&#xf0;',
+      '&#xf0' => '&amp;#xf0',
+      '&#x;' => '&amp;#x;',
+      '&#xfoo;' => '&amp;#xfoo;',
+      '&#;' => '&amp;#;',
+      '&#foo;' => '&amp;#foo;',
+      'foo&amp;bar' => 'foo&amp;bar',
+    }.each do |(input, output)|
+      assert_equal output, EscapeUtils.escape_html_once(input)
+      assert_equal output, EscapeUtils.escape_html_once_as_html_safe(input)
+    end
+  end
+
   def test_html_safe_escape_default_works
     str = EscapeUtils.escape_html_as_html_safe('foobar')
     assert_equal 'foobar', str


### PR DESCRIPTION
Rebased version of https://github.com/brianmario/escape_utils/pull/76
Fix: #76 

> This is a port of ActiveSupport's `ERB::Util.html_escape_once` method, which uses this regex to match characters that need encoding, while ignoring existing complete HTML entities.

I re-did the benchmark, I think the perf difference makes it still relevant:

```
Comparison:
EscapeUtils.escape_html_once:     2056.0 i/s
ERB::Util.html_escape_once:      148.3 i/s - 13.86x  (± 0.00) slower
```