### PR TITLE
Use a length table rather than to invoke strlen

### DIFF
--- a/benchmark/html_escape_once.rb
+++ b/benchmark/html_escape_once.rb
@@ -13,12 +13,12 @@ html = html.force_encoding('utf-8') if html.respond_to?(:force_encoding)
 puts "Escaping #{html.bytesize} bytes of html from #{url}"
 
 Benchmark.ips do |x|
-  x.report "EscapeUtils.escape_html_once" do
-    EscapeUtils.escape_html_once(html)
-  end
-
   x.report "ActionView escape_once" do # Rails expose it as ERB::Util.html_escape_once
     ERB::Util.html_escape_once(html)
+  end
+
+  x.report "EscapeUtils.escape_html_once" do
+    EscapeUtils.escape_html_once(html)
   end
 
   x.compare!(order: :baseline)

--- a/benchmark/xml_escape.rb
+++ b/benchmark/xml_escape.rb
@@ -13,17 +13,13 @@ xml = xml.force_encoding('binary') if xml.respond_to?(:force_encoding)
 puts "Escaping #{xml.bytesize} bytes of xml, from #{url}"
 
 Benchmark.ips do |x|
-  x.report "fast_xs" do |times|
-    times.times do
-      xml.fast_xs
-    end
+  x.report "fast_xs" do
+    xml.fast_xs
   end
 
-  x.report "EscapeUtils.escape_xml" do |times|
-    times.times do
-      EscapeUtils.escape_xml(xml)
-    end
+  x.report "EscapeUtils.escape_xml" do
+    EscapeUtils.escape_xml(xml)
   end
 
-  x.compare!
+  x.compare!(order: :baseline)
 end

--- a/ext/escape_utils/houdini_html_e.c
+++ b/ext/escape_utils/houdini_html_e.c
@@ -35,12 +35,21 @@ static const char HTML_ESCAPE_TABLE[] = {
 };
 
 static const char *HTML_ESCAPES[] = {
-        "",
-        "&quot;",
-        "&amp;",
-        "&#39;",
-        "&lt;",
-        "&gt;"
+	"",
+	"&quot;",
+	"&amp;",
+	"&#39;",
+	"&lt;",
+	"&gt;"
+};
+
+static const int HTML_ESCAPES_LENGTHS[] = {
+	0,
+	6,
+	5,
+	5,
+	4,
+	4
 };
 
 static int
@@ -100,7 +109,7 @@ houdini_escape_html_once(gh_buf *ob, const uint8_t *src, size_t size)
 		if (unlikely(i >= size))
 			break;
 
-		gh_buf_puts(ob, HTML_ESCAPES[esc]);
+		gh_buf_put(ob, HTML_ESCAPES[esc], HTML_ESCAPES_LENGTHS[esc]);
 
 		i++;
 	}

--- a/ext/escape_utils/houdini_xml_e.c
+++ b/ext/escape_utils/houdini_xml_e.c
@@ -25,6 +25,20 @@ static const char *LOOKUP_CODES[] = {
 	"&gt;"
 };
 
+static const int LOOKUP_CODES_LENGTHS[] = {
+	0,
+	0,
+	0,
+	0,
+	0,
+	1,
+	6,
+	5,
+	6,
+	4,
+	4
+};
+
 static const char CODE_INVALID = 5;
 
 static const char XML_LOOKUP_TABLE[] = {
@@ -129,7 +143,7 @@ houdini_escape_xml(gh_buf *ob, const uint8_t *src, size_t size)
 		if (end >= size)
 			break;
 
-		gh_buf_puts(ob, LOOKUP_CODES[code]);
+		gh_buf_put(ob, LOOKUP_CODES[code], LOOKUP_CODES_LENGTHS[code]);
 	}
 
 	return 1;


### PR DESCRIPTION
The strings are small, but we can still see a difference.

Before:
```
Comparison:
  EscapeUtils.escape_html_once:     2409.6 i/s
  ActionView escape_once:            148.7 i/s - 16.21x  (± 0.00) slower
```

After:

```
Comparison:
  EscapeUtils.escape_html_once:     2548.2 i/s
  ActionView escape_once:            148.8 i/s - 17.12x  (± 0.00) slower
```

`escape_xml` sees a similar speedup.