### PR TITLE
Add shebang line since this file is executable

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,2 +1,3 @@
+#!/bin/sh
 bundle install --path vendor/gems --binstubs
 bin/rake clobber clean compile


### PR DESCRIPTION
I noticed this during our RPM packaging phase in our product where RPM complains with the following warning:

```
*** WARNING: ./opt/manageiq/manageiq-gemset/gems/escape_utils-1.3.0/script/bootstrap is executable but has no shebang, removing executable bit
```

See also https://fedoraproject.org/wiki/Common_Rpmlint_issues#script-without-shebang

---

Separately, I can't tell where this file is actually used.  It's not called anywhere nor mentioned in documentation.  Is it even needed?