### PR TITLE
Remove dev-only files from the final packaged gem

### DIFF
--- a/escape_utils.gemspec
+++ b/escape_utils.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.4.2}
   s.summary = %q{Faster string escaping routines for your web apps}
   s.description = %q{Quickly perform HTML, URL, URI and Javascript escaping/unescaping}
-  s.test_files = `git ls-files test`.split("\n")
+  s.files = `git ls-files -z`.split("\x0").reject { |f| f.match?(%r{^(\.github|benchmark|test|script)/}) }
+  s.test_files = `git ls-files -z test`.split("\x0")
 
   s.required_ruby_version = ">= 2.5"
 end


### PR DESCRIPTION
Based on https://github.com/brianmario/escape_utils/pull/82#issuecomment-1299106166

This PR removes the .github, benchmark, and script directories from the final packaged gem. The test files will still be present because they are enumerated in `s.test_files`, so if we don't need those in the packaged gem, then that line can also be removed.

@byroot Please review.